### PR TITLE
Update accessory registration

### DIFF
--- a/src/schedule-accessory.ts
+++ b/src/schedule-accessory.ts
@@ -20,7 +20,7 @@ let hap: HAP;
  */
 export = (api: API) => {
 	hap = api.hap;
-	api.registerAccessory('Schedule', ScheduleAccessory);
+	api.registerAccessory('homebridge-schedule', 'Schedule', ScheduleAccessory);
 };
 
 class ScheduleAccessory implements AccessoryPlugin {


### PR DESCRIPTION
Add HOOBS compatibility by registering the accessory with the plugin name.

Regarding issues: https://github.com/kbrashears5/homebridge-schedule/issues/6
https://github.com/hoobs-org/HOOBS/issues/703
