### PR TITLE
Added new optional config option 'enabledDuration' to customize switch enabled duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ dist
 
 # test results
 junit.xml
+
+# jetbrains ide
+.idea/

--- a/README.md
+++ b/README.md
@@ -37,24 +37,28 @@ Add accessories to your `config.json` similar to below for interval based schedu
       "accessory": "Schedule",
       "name": "Hourly",
       "interval": 60,
-      "serial": "123456789"
+      "serial": "123456789",
+      "enabledDuration": 10
     }
   ]
 }
 ```
 
-| Property  | Description                                                           |
-| --------- | --------------------------------------------------------------------- |
-| Accessory | Must be "Schedule"                                                    |
-| Name      | Unique name for the dummy switch                                      |
-| Interval  | Interval, in minutes                                                  |
-| Serial    | Serial number to give the accessory in HomeKit. Defaults to 123456789 |
+| Property         | Description                                                                      |
+|------------------|----------------------------------------------------------------------------------|
+| Accessory        | Must be "Schedule"                                                               |
+| Name             | Unique name for the dummy switch                                                 |
+| Interval         | Interval, in minutes                                                             |
+| Serial           | Serial number to give the accessory in HomeKit. Defaults to 123456789            |
+| Enabled Duration | Number of seconds to leave switch enabled before disabling. Defaults to 1 second |
 
 Upon startup of Homebridge, the device will turn on at the specified interval
 
 #### Notes
 
 The interval starts when Homebridge is started up. If you want something to run hourly on the hour, then you need to make sure Homebridge is started up on the hour
+
+Rarely, if your HomeKit bridge is too sluggish to detect Homebridge Schedule switches turning on and off, you can configure an Enabled Duration to have the switches remain on longer
 
 ### Cron Based
 
@@ -73,12 +77,13 @@ Add accessories to your `config.json` similar to below for cron based schedules:
 }
 ```
 
-| Property  | Description                                                           |
-| --------- | --------------------------------------------------------------------- |
-| Accessory | Must be "Schedule"                                                    |
-| Name      | Unique name for the dummy switch                                      |
-| Cron      | Cron string                                                           |
-| Serial    | Serial number to give the accessory in HomeKit. Defaults to 123456789 |
+| Property         | Description                                                                      |
+|------------------|----------------------------------------------------------------------------------|
+| Accessory        | Must be "Schedule"                                                               |
+| Name             | Unique name for the dummy switch                                                 |
+| Cron             | Cron string                                                                      |
+| Serial           | Serial number to give the accessory in HomeKit. Defaults to 123456789            |
+| Enabled Duration | Number of seconds to leave switch enabled before disabling. Defaults to 1 second |
 
 Cron string details: https://www.npmjs.com/package/cron
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -25,6 +25,12 @@
         "title": "Cron",
         "type": "string",
         "description": "Cron string"
+      },
+      "enabledDuration": {
+        "title": "Enabled Duration",
+        "type": "number",
+        "description": "Number of seconds to leave switch on for before disabling",
+        "required": false
       }
     }
   }

--- a/src/schedule-accessory.ts
+++ b/src/schedule-accessory.ts
@@ -21,6 +21,7 @@ class ScheduleAccessory implements AccessoryPlugin {
   private readonly name: string;
   private readonly serial: string;
   private scheduleOn = false;
+  private enabledDuration: number;
 
   private readonly switchService: Service;
   private readonly informationService: Service;
@@ -33,12 +34,14 @@ class ScheduleAccessory implements AccessoryPlugin {
     this.log = log;
     this.name = config.name;
     this.serial = (config.serial ?? '123456789').trim();
+    this.enabledDuration = ((config.enabledDuration ?? 1) * 1000);
 
     // log config parameters
     log.debug(`Name: [${config.name}]`);
     log.debug(`Interval: [${config.interval}]`);
     log.debug(`Cron: [${config.cron}]`);
     log.debug(`Serial: [${config.serial}]`);
+    log.debug(`Enabled Duration: [${config.enabledDuration}]`);
 
     // determine what was provided by config
     let intervalSupplied = true;
@@ -86,7 +89,7 @@ class ScheduleAccessory implements AccessoryPlugin {
           if (value) {
             setTimeout(() => {
               this.switchService.setCharacteristic('On', false);
-            }, 1000);
+            }, this.enabledDuration);
           }
 
           callback();


### PR DESCRIPTION
In my personal HomeKit setup I tried to utilize typescript-homebridge-schedule but after some troubleshooting, I noticed that my HomeKit bridge was too sluggish to notice the typescript-homebridge-schedule switches turning on and off most of the time. Unsure if this is due to the number of accessories in my home, or the signal strength of my current primary bridge or the fact that I have 20 HomeKit bridges.

Either way, I believe adding a configuration option to allow users to customize how long the typescript-homebridge-schedule switches stay enabled will resolve this issue and allow me to use typescript-homebridge-schedule switches reliably.

I was having some issues installing dependencies so I didn't get to test this, but it's fairly straightforward.